### PR TITLE
Fixed lines link in READMEs

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -111,7 +111,7 @@ Basically, the data returned are available in JSON format. It's possible to get 
 
 Example of request to retrieve all metro lignes [(link to documentation)](https://api-ratp.pierre-grimaud.fr/v3/documentation#section-Lines): 
 
-    https://api-ratp.pierre-grimaud.fr/v3/metros
+    https://api-ratp.pierre-grimaud.fr/v3/lines/metros
     
     {
         "result": {

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ De base, les données renvoyées sont disponibles au format JSON. Mais il est po
 
 Exemple de requête pour récupérer toutes les lignes du métro [(lien vers la documentation)](https://api-ratp.pierre-grimaud.fr/v3/documentation#section-Lines): 
 
-    https://api-ratp.pierre-grimaud.fr/v3/metros
+    https://api-ratp.pierre-grimaud.fr/v3/lines/metros
     
     {
         "result": {


### PR DESCRIPTION
Example of the lines request led to a 404. Changed it to the correct request.